### PR TITLE
fix: change catalog page API call from POST to GET

### DIFF
--- a/server/controllers/Category.js
+++ b/server/controllers/Category.js
@@ -49,7 +49,7 @@ exports.showAllCategories = async (req, res) => {
 
 exports.categoryPageDetails = async (req, res) => {
     try {
-      const { categoryId } = req.body
+      const { categoryId } = req.query
       console.log("PRINTING CATEGORY ID: ", categoryId);
       // Get courses for the specified category
       const selectedCategory = await Category.findById(categoryId)

--- a/server/routes/Course.js
+++ b/server/routes/Course.js
@@ -74,7 +74,7 @@ router.post("/updateCourseProgress", auth, isStudent, updateCourseProgress);
 // ── Categories ────────────────────────────────────────────────────────────────
 router.post("/createCategory",        auth, isAdmin, createCategory);
 router.get("/showAllCategories",      showAllCategories);
-router.post("/getCategoryPageDetail", categoryPageDetails);
+router.get("/getCategoryPageDetail", categoryPageDetails);
 
 // ── Sections ──────────────────────────────────────────────────────────────────
 router.post("/addSection",    auth, isInstructor, createSection);

--- a/src/services/apis.js
+++ b/src/services/apis.js
@@ -58,7 +58,7 @@ export const categories = {
 
 // CATALOG PAGE DATA
 export const catalogData = {
-  CATALOGPAGEDATA_API: BASE_URL + "/course/getCategoryPageDetails",
+  CATALOGPAGEDATA_API: BASE_URL + "/course/getCategoryPageDetail",
 }
 // CONTACT-US API
 export const contactusEndpoint = {

--- a/src/services/operations/pageAndComponentData.js
+++ b/src/services/operations/pageAndComponentData.js
@@ -7,8 +7,8 @@ export const getCatalogaPageData = async(categoryId) => {
   const toastId = toast.loading("Loading...");
   let result = [];
   try{
-        const response = await apiConnector("POST", catalogData.CATALOGPAGEDATA_API, 
-        {categoryId: categoryId,});
+        const response = await apiConnector("GET", catalogData.CATALOGPAGEDATA_API,
+        null, null, {categoryId: categoryId});
 
         if(!response?.data?.success)
             throw new Error("Could not Fetch Category page data");


### PR DESCRIPTION
## What changed

- `src/services/operations/pageAndComponentData.js`: changed `apiConnector("POST", ...)` with body data to `apiConnector("GET", ...)` with query params
- `src/services/apis.js`: corrected endpoint name from `getCategoryPageDetails` (plural) to `getCategoryPageDetail` to match the backend route
- `server/routes/Course.js`: changed `router.post("/getCategoryPageDetail", ...)` to `router.get(...)` to align with REST convention
- `server/controllers/Category.js`: changed `req.body` to `req.query` so the handler reads `categoryId` from the query string on GET requests

## Why

The category page data endpoint was registered as POST in the route but semantically should be GET (it fetches data, mutates nothing). The frontend was sending a POST with the `categoryId` in the request body. The backend route and controller have been updated to match, and the frontend now sends `categoryId` as a query parameter.

There was also a secondary bug: the URL constant in `apis.js` had a trailing `s` (`getCategoryPageDetails`) that didn't match the backend route (`getCategoryPageDetail`), causing a 404.

## How to test

1. Start the server (`npm start` in `/server`)
2. Start the frontend (`npm start` in the project root)
3. Navigate to any category page — courses should load correctly

Closes #26