### PR TITLE
feat: implement trie-based search auto-suggestions

### DIFF
--- a/server/__tests__/trie.test.js
+++ b/server/__tests__/trie.test.js
@@ -1,0 +1,46 @@
+const Trie = require("../utils/trie");
+
+describe("Trie", () => {
+  let trie;
+
+  beforeEach(() => {
+    trie = new Trie();
+  });
+
+  it("returns empty array for unknown prefix", () => {
+    trie.insert("React Basics", { type: "course", id: "1" });
+    expect(trie.search("vue")).toEqual([]);
+  });
+
+  it("finds suggestions by prefix (case-insensitive)", () => {
+    trie.insert("React Basics", { type: "course", id: "1", courseId: "1" });
+    trie.insert("Reading Skills", { type: "course", id: "2", courseId: "2" });
+
+    const results = trie.search("rea");
+    expect(results).toHaveLength(2);
+    expect(results.map((r) => r.label)).toEqual(
+      expect.arrayContaining(["React Basics", "Reading Skills"])
+    );
+  });
+
+  it("deduplicates entries with the same type and id", () => {
+    trie.insert("React", { type: "course", id: "1", courseId: "1" });
+    trie.insert("react", { type: "course", id: "1", courseId: "1" });
+
+    expect(trie.search("re")).toHaveLength(1);
+  });
+
+  it("respects the result limit", () => {
+    trie.insert("Alpha", { type: "course", id: "1" });
+    trie.insert("Apple", { type: "course", id: "2" });
+    trie.insert("Application", { type: "course", id: "3" });
+
+    expect(trie.search("a", 2)).toHaveLength(2);
+  });
+
+  it("clears all entries", () => {
+    trie.insert("Node.js", { type: "course", id: "1" });
+    trie.clear();
+    expect(trie.search("node")).toEqual([]);
+  });
+});

--- a/server/controllers/Course.js
+++ b/server/controllers/Course.js
@@ -6,6 +6,13 @@ const User = require("../models/User")
 const { uploadImageToCloudinary } = require("../utils/imageUploader")
 const CourseProgress = require("../models/CourseProgress")
 const { convertSecondsToDuration } = require("../utils/secToDuration")
+const searchIndex = require("../services/searchIndex")
+
+const refreshSearchIndex = () => {
+  searchIndex.rebuild().catch((err) => {
+    console.error("[SearchIndex] Rebuild failed:", err.message)
+  })
+}
 // Function to create a new course
 exports.createCourse = async (req, res) => {
   try {
@@ -115,6 +122,7 @@ exports.createCourse = async (req, res) => {
       { new: true }
     )
     console.log("HEREEEEEEEE", categoryDetails2)
+    refreshSearchIndex()
     // Return the new course and a success message
     res.status(200).json({
       success: true,
@@ -185,6 +193,7 @@ exports.editCourse = async (req, res) => {
       })
       .exec()
 
+    refreshSearchIndex()
     res.json({
       success: true,
       message: "Course updated successfully",
@@ -477,6 +486,7 @@ exports.deleteCourse = async (req, res) => {
     // Delete the course
     await Course.findByIdAndDelete(courseId)
 
+    refreshSearchIndex()
     return res.status(200).json({
       success: true,
       message: "Course deleted successfully",
@@ -490,6 +500,36 @@ exports.deleteCourse = async (req, res) => {
     })
   }
 }
+
+// Trie-backed search auto-suggestions
+exports.getSearchSuggestions = async (req, res) => {
+  try {
+    const { query, limit } = req.query;
+    const trimmedQuery = (query || "").trim();
+
+    if (!trimmedQuery) {
+      return res.status(200).json({
+        success: true,
+        data: [],
+      });
+    }
+
+    const maxResults = Math.min(parseInt(limit, 10) || 8, 20);
+    const suggestions = searchIndex.getSuggestions(trimmedQuery, maxResults);
+
+    return res.status(200).json({
+      success: true,
+      data: suggestions,
+    });
+  } catch (error) {
+    console.error(error);
+    return res.status(500).json({
+      success: false,
+      message: "Failed to fetch search suggestions",
+      error: error.message,
+    });
+  }
+};
 
 // Search Courses by query (including instructor name)
 exports.searchCourse = async (req, res) => {

--- a/server/index.js
+++ b/server/index.js
@@ -55,6 +55,7 @@ const aiRoutes        = require("./routes/AI");
 // ── Infrastructure ────────────────────────────────────────────────────
 const database           = require("./config/database");
 const { cloudinaryConnect } = require("./config/cloudinary");
+const searchIndex        = require("./services/searchIndex");
 
 const app  = express();
 const PORT = process.env.PORT || 4000;
@@ -100,7 +101,15 @@ if (process.env.NODE_ENV !== "test") {
   const mongoose = require("mongoose");
   mongoose
     .connect(process.env.MONGODB_URL, mongooseOptions)
-    .then(() => console.log("DB Connected Successfully"))
+    .then(async () => {
+      console.log("DB Connected Successfully");
+      try {
+        const count = await searchIndex.rebuild();
+        console.log(`[SearchIndex] Indexed ${count} published courses`);
+      } catch (err) {
+        console.error("[SearchIndex] Initial build failed:", err.message);
+      }
+    })
     .catch((err) => {
       console.error("DB Connection Failed:", err);
       process.exit(1);

--- a/server/routes/Course.js
+++ b/server/routes/Course.js
@@ -9,6 +9,9 @@ const {
   editCourse,
   deleteCourse,
   getInstructorCourses,
+  searchCourse,
+  getSearchSuggestions,
+  instructorDetails,
 } = require("../controllers/Course");
 
 const {
@@ -54,6 +57,11 @@ const {
 // ── Recommendations ───────────────────────────────────────────────────────────
 // Works for guests (no token) and logged-in students (personalised)
 router.get("/recommendations", optionalAuth, getRecommendations);
+
+// ── Search ────────────────────────────────────────────────────────────────────
+router.get("/searchSuggestions", getSearchSuggestions);
+router.get("/searchCourse", searchCourse);
+router.get("/instructorDetails/:instructorId", instructorDetails);
 
 // Content-similar courses – shown on the course detail page
 router.get("/:courseId/similar", getSimilarCourses);

--- a/server/services/searchIndex.js
+++ b/server/services/searchIndex.js
@@ -1,0 +1,77 @@
+const Course = require("../models/Course");
+const Trie = require("../utils/trie");
+
+const trie = new Trie();
+let isReady = false;
+
+function indexCourse(course) {
+  const instructor = course.instructor;
+  const instructorName = instructor
+    ? [instructor.firstName, instructor.lastName].filter(Boolean).join(" ")
+    : "";
+
+  trie.insert(course.courseName, {
+    type: "course",
+    id: course._id.toString(),
+    courseId: course._id.toString(),
+    thumbnail: course.thumbnail,
+    instructorName,
+  });
+
+  if (instructor && instructor._id) {
+    trie.insert(instructorName, {
+      type: "instructor",
+      id: instructor._id.toString(),
+      instructorId: instructor._id.toString(),
+      image: instructor.image,
+    });
+  }
+
+  if (Array.isArray(course.tag)) {
+    for (const tag of course.tag) {
+      trie.insert(tag, {
+        type: "tag",
+        id: tag.toLowerCase(),
+        courseId: course._id.toString(),
+      });
+    }
+  }
+
+  if (course.category?.name) {
+    trie.insert(course.category.name, {
+      type: "category",
+      id: course.category._id.toString(),
+      courseId: course._id.toString(),
+    });
+  }
+}
+
+async function rebuild() {
+  trie.clear();
+
+  const courses = await Course.find({ status: "Published" })
+    .populate("instructor", "firstName lastName image")
+    .populate("category", "name")
+    .lean();
+
+  for (const course of courses) {
+    indexCourse(course);
+  }
+
+  isReady = true;
+  return courses.length;
+}
+
+function getSuggestions(prefix, limit = 8) {
+  return trie.search(prefix, limit);
+}
+
+function ready() {
+  return isReady;
+}
+
+module.exports = {
+  rebuild,
+  getSuggestions,
+  ready,
+};

--- a/server/utils/trie.js
+++ b/server/utils/trie.js
@@ -1,0 +1,79 @@
+class TrieNode {
+  constructor() {
+    this.children = new Map();
+    this.entries = [];
+  }
+}
+
+class Trie {
+  constructor() {
+    this.root = new TrieNode();
+  }
+
+  _normalize(text) {
+    return text.trim().toLowerCase();
+  }
+
+  insert(text, metadata) {
+    const normalized = this._normalize(text);
+    if (!normalized) return;
+
+    let node = this.root;
+    for (const char of normalized) {
+      if (!node.children.has(char)) {
+        node.children.set(char, new TrieNode());
+      }
+      node = node.children.get(char);
+    }
+
+    const key = `${metadata.type}:${metadata.id}`;
+    const exists = node.entries.some(
+      (entry) => `${entry.type}:${entry.id}` === key
+    );
+    if (!exists) {
+      node.entries.push({ ...metadata, label: text.trim() });
+    }
+  }
+
+  search(prefix, limit = 8) {
+    const normalized = this._normalize(prefix);
+    if (!normalized) return [];
+
+    let node = this.root;
+    for (const char of normalized) {
+      if (!node.children.has(char)) {
+        return [];
+      }
+      node = node.children.get(char);
+    }
+
+    const results = [];
+    const seen = new Set();
+    this._collectSuggestions(node, results, seen, limit);
+    return results;
+  }
+
+  _collectSuggestions(node, results, seen, limit) {
+    if (results.length >= limit) return;
+
+    for (const entry of node.entries) {
+      const key = `${entry.type}:${entry.id}`;
+      if (!seen.has(key)) {
+        seen.add(key);
+        results.push(entry);
+        if (results.length >= limit) return;
+      }
+    }
+
+    for (const child of node.children.values()) {
+      this._collectSuggestions(child, results, seen, limit);
+      if (results.length >= limit) return;
+    }
+  }
+
+  clear() {
+    this.root = new TrieNode();
+  }
+}
+
+module.exports = Trie;

--- a/src/App.js
+++ b/src/App.js
@@ -45,7 +45,7 @@ function App() {
         <Route path="/" element={<Home />} />
         <Route path="about" element={<About />} />
         <Route path="contact" element={<Contact />} />
-        <Route path="search" element={<Search />} />
+        <Route path="search/:query" element={<Search />} />
         <Route path="error" element={<Error />} />
         <Route path="/catalog/:catalogName" element={<Catalog />} />
         <Route path="/courses/:courseId" element={<CourseDetails />} />

--- a/src/components/common/Navbar.jsx
+++ b/src/components/common/Navbar.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useRef } from "react"
+import { useEffect, useState, useRef, useCallback } from "react"
 import { AiOutlineShoppingCart } from "react-icons/ai"
 import { IoMdMore } from "react-icons/io";
 import { RxCross1 } from "react-icons/rx";
@@ -12,8 +12,8 @@ import { apiConnector } from "../../services/apiconnector"
 import { categories } from "../../services/apis"
 import { ACCOUNT_TYPE } from "../../utils/constants"
 import ProfileDropdown from "../core/Auth/ProfileDropDown"
-import { useNavigate } from "react-router-dom";
-import { searchEndpoints } from "../../services/apis"
+import SearchBar from "./SearchBar"
+import useOnClickOutside from "../../hooks/useOnClickOutside"
 
 function Navbar() {
   const { token } = useSelector((state) => state.auth)
@@ -26,29 +26,25 @@ function Navbar() {
 
   // Search bar state
   const [searchQuery, setSearchQuery] = useState("");
-  const navigate = useNavigate();
-  
-  // Handle search submit
-  const handleSearchSubmit = async (e) => {
-    e.preventDefault();
-    if (!searchQuery.trim()) return;
-    try {
-      const res = await apiConnector(
-        "GET", 
-        searchEndpoints.COURSE_SEARCH_API + `?query=${encodeURIComponent(searchQuery)}`
-      );
-
-      console.log("Search results:", res.data);
-      navigate(`/search/${encodeURIComponent(searchQuery)}`);
-    } catch (error) {
-      console.error("Search failed:", error);
-    }
-  };
   const [showSearch, setShowSearch] = useState(false);
+
+  const closeSearch = useCallback(() => {
+    setShowSearch(false);
+    setSearchQuery("");
+  }, []);
 
   // refs for search inputs (desktop & mobile)
   const desktopSearchRef = useRef(null);
   const mobileSearchRef = useRef(null);
+  const desktopSearchContainerRef = useRef(null);
+  const mobileSearchContainerRef = useRef(null);
+
+  useOnClickOutside(desktopSearchContainerRef, () => {
+    if (showSearch) closeSearch();
+  });
+  useOnClickOutside(mobileSearchContainerRef, () => {
+    if (showSearch) closeSearch();
+  });
 
   // helper to detect visible element
   const isElementVisible = (el) => {
@@ -179,7 +175,7 @@ function Navbar() {
         {/* Login / Signup / Dashboard */}
           <div className="hidden items-center gap-x-4 md:flex">
             {/* Search Icon and Search Bar */}
-            <div className="relative">
+            <div className="relative" ref={desktopSearchContainerRef}>
               <button
                 className="p-2"
                 onClick={toggleSearch}
@@ -203,17 +199,12 @@ function Navbar() {
               : "opacity-0 invisible -translate-y-2"
                 }`}
               >
-            <form onSubmit={handleSearchSubmit}>
-              <input
-                type="text"
-                className="w-full rounded-md border border-richblack-700 bg-richblack-800 px-3 py-2 text-richblack-100 focus:outline-none focus:ring-2 focus:ring-yellow-50"
-                placeholder="Search courses..."
-                ref={desktopSearchRef}
-                value={searchQuery}
-                onChange={(e) => setSearchQuery(e.target.value)}
-                onBlur={() => setShowSearch(false)}
-              />
-            </form>
+            <SearchBar
+              ref={desktopSearchRef}
+              value={searchQuery}
+              onChange={setSearchQuery}
+              onClose={closeSearch}
+            />
               </div>
             </div>
             {user && user?.accountType !== ACCOUNT_TYPE.INSTRUCTOR && (
@@ -257,7 +248,7 @@ function Navbar() {
               )}
             </Link>
           )}
-            <div className="relative">
+            <div className="relative" ref={mobileSearchContainerRef}>
               <button
                 className="p-2"
                 onClick={toggleSearch}
@@ -281,17 +272,12 @@ function Navbar() {
                 : "opacity-0 invisible -translate-y-2"
                 }`}
               >
-                <form onSubmit={handleSearchSubmit}>
-                <input
-                  type="text"
-                  className="w-full rounded-md border border-richblack-700 bg-richblack-800 px-3 py-2 text-richblack-100 focus:outline-none focus:ring-2 focus:ring-yellow-50"
-                  placeholder="Search courses..."
+                <SearchBar
                   ref={mobileSearchRef}
                   value={searchQuery}
-                  onChange={(e) => setSearchQuery(e.target.value)}
-                  onBlur={() => setShowSearch(false)}
+                  onChange={setSearchQuery}
+                  onClose={closeSearch}
                 />
-                </form>
               </div>
             </div>
           <button className="md:hidden" onClick={() => setOpen(!open)}>

--- a/src/components/common/SearchBar.jsx
+++ b/src/components/common/SearchBar.jsx
@@ -1,0 +1,98 @@
+import { forwardRef, useCallback, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import useSearchSuggestions from "../../hooks/useSearchSuggestions";
+import SearchSuggestions from "./SearchSuggestions";
+
+function getSuggestionPath(suggestion) {
+  switch (suggestion.type) {
+    case "course":
+      return `/courses/${suggestion.courseId || suggestion.id}`;
+    case "instructor":
+      return `/instructor/${suggestion.instructorId || suggestion.id}`;
+    default:
+      return `/search/${encodeURIComponent(suggestion.label)}`;
+  }
+}
+
+const SearchBar = forwardRef(function SearchBar(
+  { value, onChange, onClose },
+  inputRef
+) {
+  const navigate = useNavigate();
+  const { suggestions, loading } = useSearchSuggestions(value);
+  const [activeIndex, setActiveIndex] = useState(-1);
+
+  const navigateToSearch = useCallback(
+    (query) => {
+      const trimmed = query.trim();
+      if (!trimmed) return;
+      navigate(`/search/${encodeURIComponent(trimmed)}`);
+      onClose?.();
+    },
+    [navigate, onClose]
+  );
+
+  const handleSelect = useCallback(
+    (suggestion) => {
+      navigate(getSuggestionPath(suggestion));
+      onClose?.();
+    },
+    [navigate, onClose]
+  );
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    if (activeIndex >= 0 && suggestions[activeIndex]) {
+      handleSelect(suggestions[activeIndex]);
+      return;
+    }
+    navigateToSearch(value);
+  };
+
+  const handleKeyDown = (e) => {
+    if (!suggestions.length) return;
+
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      setActiveIndex((prev) =>
+        prev < suggestions.length - 1 ? prev + 1 : 0
+      );
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      setActiveIndex((prev) =>
+        prev > 0 ? prev - 1 : suggestions.length - 1
+      );
+    } else if (e.key === "Escape") {
+      onClose?.();
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="relative">
+      <input
+        type="text"
+        className="w-full rounded-md border border-richblack-700 bg-richblack-800 px-3 py-2 text-richblack-100 focus:outline-none focus:ring-2 focus:ring-yellow-50"
+        placeholder="Search courses..."
+        ref={inputRef}
+        value={value}
+        onChange={(e) => {
+          setActiveIndex(-1);
+          onChange(e.target.value);
+        }}
+        onKeyDown={handleKeyDown}
+        autoComplete="off"
+        aria-autocomplete="list"
+        aria-expanded={value.trim().length > 0}
+      />
+      <SearchSuggestions
+        suggestions={suggestions}
+        loading={loading}
+        activeIndex={activeIndex}
+        onSelect={handleSelect}
+        query={value}
+      />
+    </form>
+  );
+});
+
+export default SearchBar;

--- a/src/components/common/SearchSuggestions.jsx
+++ b/src/components/common/SearchSuggestions.jsx
@@ -1,0 +1,56 @@
+import React from "react";
+
+const typeLabels = {
+  course: "Course",
+  instructor: "Instructor",
+  tag: "Tag",
+  category: "Category",
+};
+
+function SearchSuggestions({
+  suggestions,
+  loading,
+  activeIndex,
+  onSelect,
+  query,
+}) {
+  const trimmed = query.trim();
+  if (trimmed.length < 1) return null;
+
+  const showEmpty = !loading && suggestions.length === 0;
+
+  return (
+    <ul
+      className="absolute left-0 right-0 top-full z-50 mt-1 max-h-64 overflow-y-auto rounded-md border border-richblack-700 bg-richblack-800 py-1 shadow-lg"
+      role="listbox"
+    >
+      {loading && suggestions.length === 0 && (
+        <li className="px-3 py-2 text-sm text-richblack-300">Searching...</li>
+      )}
+
+      {suggestions.map((item, index) => (
+        <li
+          key={`${item.type}-${item.id}-${index}`}
+          role="option"
+          aria-selected={index === activeIndex}
+          className={`cursor-pointer px-3 py-2 text-sm text-richblack-100 ${
+            index === activeIndex ? "bg-richblack-700" : "hover:bg-richblack-700"
+          }`}
+          onMouseDown={(e) => e.preventDefault()}
+          onClick={() => onSelect(item)}
+        >
+          <span className="font-medium">{item.label}</span>
+          <span className="ml-2 text-xs text-richblack-400">
+            {typeLabels[item.type] || item.type}
+          </span>
+        </li>
+      ))}
+
+      {showEmpty && (
+        <li className="px-3 py-2 text-sm text-richblack-300">No suggestions</li>
+      )}
+    </ul>
+  );
+}
+
+export default SearchSuggestions;

--- a/src/hooks/useSearchSuggestions.js
+++ b/src/hooks/useSearchSuggestions.js
@@ -1,0 +1,61 @@
+import { useEffect, useRef, useState } from "react";
+import { axiosInstance } from "../services/apiconnector";
+import { searchEndpoints } from "../services/apis";
+
+const DEBOUNCE_MS = 300;
+const MIN_QUERY_LENGTH = 1;
+
+export default function useSearchSuggestions(query) {
+  const [suggestions, setSuggestions] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const abortRef = useRef(null);
+
+  useEffect(() => {
+    const trimmed = query.trim();
+
+    if (trimmed.length < MIN_QUERY_LENGTH) {
+      setSuggestions([]);
+      setLoading(false);
+      return;
+    }
+
+    setLoading(true);
+    const timer = setTimeout(async () => {
+      if (abortRef.current) {
+        abortRef.current.abort();
+      }
+
+      const controller = new AbortController();
+      abortRef.current = controller;
+
+      try {
+        const res = await axiosInstance({
+          method: "GET",
+          url: `${searchEndpoints.SEARCH_SUGGESTIONS_API}?query=${encodeURIComponent(trimmed)}&limit=8`,
+          signal: controller.signal,
+        });
+
+        if (!controller.signal.aborted) {
+          setSuggestions(Array.isArray(res.data.data) ? res.data.data : []);
+        }
+      } catch (error) {
+        if (error.name !== "CanceledError" && !controller.signal.aborted) {
+          setSuggestions([]);
+        }
+      } finally {
+        if (!controller.signal.aborted) {
+          setLoading(false);
+        }
+      }
+    }, DEBOUNCE_MS);
+
+    return () => {
+      clearTimeout(timer);
+      if (abortRef.current) {
+        abortRef.current.abort();
+      }
+    };
+  }, [query]);
+
+  return { suggestions, loading };
+}

--- a/src/services/apis.js
+++ b/src/services/apis.js
@@ -101,6 +101,7 @@ export const mlEndpoints = {
 // SEARCH API
 export const searchEndpoints = {
   COURSE_SEARCH_API: BASE_URL + "/course/searchCourse",
+  SEARCH_SUGGESTIONS_API: BASE_URL + "/course/searchSuggestions",
   INSTRUCTOR_SEARCH_API: BASE_URL + "/course/instructorDetails",
 }
 


### PR DESCRIPTION
## Summary
- Add an in-memory Trie data structure for fast prefix-based search suggestions
- Expose `GET /api/v1/course/searchSuggestions` and wire existing search routes
- Integrate debounced autocomplete dropdown in the navbar with keyboard navigation
- Fix search results route to `/search/:query`

Closes #43

## Test plan
- [x] Start server and confirm `[SearchIndex] Indexed N published courses` in logs
- [ ] Type in navbar search — suggestions appear after ~300ms
- [ ] Select a suggestion (click or Enter) — navigates to course/instructor/search page
- [ ] Submit a full search query — `/search/:query` shows results
- [ ] Create/edit/delete a published course — suggestions update after CRUD
- [ ] Run `cd server && npm test` — trie tests pass